### PR TITLE
feat: Implement Port & UseCase layer for Upload Policy (KAN-3 Task 1.2)

### DIFF
--- a/application/src/main/java/com/ryuqq/fileflow/application/dto/CreateUploadPolicyCommand.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/dto/CreateUploadPolicyCommand.java
@@ -1,0 +1,54 @@
+package com.ryuqq.fileflow.application.dto;
+
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.vo.ExcelPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.HtmlPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.PdfPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+
+import java.time.LocalDateTime;
+
+/**
+ * UploadPolicy 생성 Command
+ *
+ * UploadPolicy를 생성하기 위한 데이터를 전달하는 Command 객체입니다.
+ *
+ * @param policyKeyDto 정책 식별자
+ * @param imagePolicy 이미지 정책 (nullable)
+ * @param htmlPolicy HTML 정책 (nullable)
+ * @param excelPolicy Excel 정책 (nullable)
+ * @param pdfPolicy PDF 정책 (nullable)
+ * @param requestsPerHour 시간당 요청 제한
+ * @param uploadsPerDay 일일 업로드 제한
+ * @param effectiveFrom 유효 시작 일시
+ * @param effectiveUntil 유효 종료 일시
+ * @author sangwon-ryu
+ */
+public record CreateUploadPolicyCommand(
+        PolicyKeyDto policyKeyDto,
+        ImagePolicy imagePolicy,
+        HtmlPolicy htmlPolicy,
+        ExcelPolicy excelPolicy,
+        PdfPolicy pdfPolicy,
+        int requestsPerHour,
+        int uploadsPerDay,
+        LocalDateTime effectiveFrom,
+        LocalDateTime effectiveUntil
+) {
+    /**
+     * Command를 검증하고 도메인 객체 생성에 필요한 값들을 반환합니다.
+     */
+    public PolicyKey getPolicyKey() {
+        return policyKeyDto.toDomain();
+    }
+
+    public FileTypePolicies getFileTypePolicies() {
+        return FileTypePolicies.of(imagePolicy, htmlPolicy, excelPolicy, pdfPolicy);
+    }
+
+    public RateLimiting getRateLimiting() {
+        return new RateLimiting(requestsPerHour, uploadsPerDay);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/dto/PolicyKeyDto.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/dto/PolicyKeyDto.java
@@ -1,0 +1,40 @@
+package com.ryuqq.fileflow.application.dto;
+
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+
+/**
+ * PolicyKey를 위한 DTO
+ *
+ * HTTP 헤더 기반 정책 식별을 위한 데이터 전송 객체입니다.
+ * {@code PolicyKey = {tenantId}:{userType}:{serviceType}}
+ *
+ * @param tenantId 테넌트 ID (예: b2c, b2b)
+ * @param userType 사용자 유형 (예: CONSUMER, SELLER, CRAWLER, BUYER)
+ * @param serviceType 서비스 유형 (예: REVIEW, PRODUCT, ORDER_SHEET)
+ * @author sangwon-ryu
+ */
+public record PolicyKeyDto(
+        String tenantId,
+        String userType,
+        String serviceType
+) {
+    /**
+     * Domain의 PolicyKey로 변환합니다.
+     *
+     * @return PolicyKey 도메인 객체
+     */
+    public PolicyKey toDomain() {
+        return PolicyKey.of(tenantId, userType, serviceType);
+    }
+
+    /**
+     * Domain의 PolicyKey로부터 DTO를 생성합니다.
+     *
+     * @param policyKey 도메인 PolicyKey
+     * @return PolicyKeyDto
+     */
+    public static PolicyKeyDto from(PolicyKey policyKey) {
+        String[] parts = policyKey.getValue().split(":");
+        return new PolicyKeyDto(parts[0], parts[1], parts[2]);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/dto/UpdateUploadPolicyCommand.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/dto/UpdateUploadPolicyCommand.java
@@ -1,0 +1,38 @@
+package com.ryuqq.fileflow.application.dto;
+
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.vo.ExcelPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.HtmlPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.PdfPolicy;
+
+/**
+ * UploadPolicy 업데이트 Command
+ *
+ * UploadPolicy를 업데이트하기 위한 데이터를 전달하는 Command 객체입니다.
+ *
+ * @param policyKeyDto 정책 식별자
+ * @param imagePolicy 새로운 이미지 정책 (nullable)
+ * @param htmlPolicy 새로운 HTML 정책 (nullable)
+ * @param excelPolicy 새로운 Excel 정책 (nullable)
+ * @param pdfPolicy 새로운 PDF 정책 (nullable)
+ * @param changedBy 변경자
+ * @author sangwon-ryu
+ */
+public record UpdateUploadPolicyCommand(
+        PolicyKeyDto policyKeyDto,
+        ImagePolicy imagePolicy,
+        HtmlPolicy htmlPolicy,
+        ExcelPolicy excelPolicy,
+        PdfPolicy pdfPolicy,
+        String changedBy
+) {
+    public PolicyKey getPolicyKey() {
+        return policyKeyDto.toDomain();
+    }
+
+    public FileTypePolicies getFileTypePolicies() {
+        return FileTypePolicies.of(imagePolicy, htmlPolicy, excelPolicy, pdfPolicy);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/dto/UploadPolicyResponse.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/dto/UploadPolicyResponse.java
@@ -1,0 +1,68 @@
+package com.ryuqq.fileflow.application.dto;
+
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.ExcelPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.HtmlPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.PdfPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+
+import java.time.LocalDateTime;
+
+/**
+ * UploadPolicy 응답 DTO
+ *
+ * UploadPolicy 조회 결과를 전달하는 응답 객체입니다.
+ *
+ * @param policyKey 정책 식별자
+ * @param imagePolicy 이미지 정책
+ * @param htmlPolicy HTML 정책
+ * @param excelPolicy Excel 정책
+ * @param pdfPolicy PDF 정책
+ * @param requestsPerHour 시간당 요청 제한
+ * @param uploadsPerDay 일일 업로드 제한
+ * @param version 버전
+ * @param isActive 활성 상태
+ * @param effectiveFrom 유효 시작 일시
+ * @param effectiveUntil 유효 종료 일시
+ * @author sangwon-ryu
+ */
+public record UploadPolicyResponse(
+        String policyKey,
+        ImagePolicy imagePolicy,
+        HtmlPolicy htmlPolicy,
+        ExcelPolicy excelPolicy,
+        PdfPolicy pdfPolicy,
+        int requestsPerHour,
+        int uploadsPerDay,
+        int version,
+        boolean isActive,
+        LocalDateTime effectiveFrom,
+        LocalDateTime effectiveUntil
+) {
+    /**
+     * Domain의 UploadPolicy로부터 Response를 생성합니다.
+     *
+     * @param uploadPolicy 도메인 UploadPolicy
+     * @return UploadPolicyResponse
+     */
+    public static UploadPolicyResponse from(UploadPolicy uploadPolicy) {
+        FileTypePolicies fileTypePolicies = uploadPolicy.getFileTypePolicies();
+        RateLimiting rateLimiting = uploadPolicy.getRateLimiting();
+
+        return new UploadPolicyResponse(
+                uploadPolicy.getPolicyKey().getValue(),
+                fileTypePolicies.getImagePolicy(),
+                fileTypePolicies.getHtmlPolicy(),
+                fileTypePolicies.getExcelPolicy(),
+                fileTypePolicies.getPdfPolicy(),
+                rateLimiting.requestsPerHour(),
+                rateLimiting.uploadsPerDay(),
+                uploadPolicy.getVersion(),
+                uploadPolicy.isActive(),
+                uploadPolicy.getEffectiveFrom(),
+                uploadPolicy.getEffectiveUntil()
+        );
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/ActivateUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/ActivateUploadPolicyUseCase.java
@@ -1,0 +1,30 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+
+/**
+ * UploadPolicy 활성화 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * UploadPolicy를 활성화하는 비즈니스 로직을 정의합니다.
+ *
+ * 비즈니스 규칙:
+ * 1. 이미 활성화된 정책은 다시 활성화할 수 없음
+ * 2. PolicyActivatedEvent 발행
+ *
+ * @author sangwon-ryu
+ */
+public interface ActivateUploadPolicyUseCase {
+
+    /**
+     * UploadPolicy를 활성화합니다.
+     *
+     * @param policyKeyDto 활성화할 정책의 키
+     * @return 활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 이미 활성화된 경우
+     */
+    UploadPolicyResponse activatePolicy(PolicyKeyDto policyKeyDto);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/CreateUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/CreateUploadPolicyUseCase.java
@@ -1,0 +1,30 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.CreateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+
+/**
+ * UploadPolicy 생성 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * 새로운 UploadPolicy를 생성하는 비즈니스 로직을 정의합니다.
+ *
+ * 비즈니스 규칙:
+ * 1. 동일한 PolicyKey를 가진 정책이 이미 존재하면 실패
+ * 2. 생성된 정책은 기본적으로 비활성화 상태
+ * 3. 버전은 1로 초기화
+ *
+ * @author sangwon-ryu
+ */
+public interface CreateUploadPolicyUseCase {
+
+    /**
+     * 새로운 UploadPolicy를 생성합니다.
+     *
+     * @param command 정책 생성 Command
+     * @return 생성된 정책 Response
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws IllegalStateException 동일한 PolicyKey를 가진 정책이 이미 존재하는 경우
+     */
+    UploadPolicyResponse createPolicy(CreateUploadPolicyCommand command);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/DeactivateUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/DeactivateUploadPolicyUseCase.java
@@ -1,0 +1,29 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+
+/**
+ * UploadPolicy 비활성화 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * UploadPolicy를 비활성화하는 비즈니스 로직을 정의합니다.
+ *
+ * 비즈니스 규칙:
+ * 1. 이미 비활성화된 정책은 다시 비활성화할 수 없음
+ *
+ * @author sangwon-ryu
+ */
+public interface DeactivateUploadPolicyUseCase {
+
+    /**
+     * UploadPolicy를 비활성화합니다.
+     *
+     * @param policyKeyDto 비활성화할 정책의 키
+     * @return 비활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 이미 비활성화된 경우
+     */
+    UploadPolicyResponse deactivatePolicy(PolicyKeyDto policyKeyDto);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/DeleteUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/DeleteUploadPolicyUseCase.java
@@ -1,0 +1,27 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+
+/**
+ * UploadPolicy 삭제 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * UploadPolicy를 삭제하는 비즈니스 로직을 정의합니다.
+ *
+ * 비즈니스 규칙:
+ * 1. 활성화된 정책은 삭제할 수 없음 (먼저 비활성화 필요)
+ *
+ * @author sangwon-ryu
+ */
+public interface DeleteUploadPolicyUseCase {
+
+    /**
+     * UploadPolicy를 삭제합니다.
+     *
+     * @param policyKeyDto 삭제할 정책의 키
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 정책이 활성화 상태인 경우
+     */
+    void deletePolicy(PolicyKeyDto policyKeyDto);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/GetUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/GetUploadPolicyUseCase.java
@@ -1,0 +1,35 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+
+/**
+ * UploadPolicy 조회 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * PolicyKey로 UploadPolicy를 조회하는 비즈니스 로직을 정의합니다.
+ *
+ * @author sangwon-ryu
+ */
+public interface GetUploadPolicyUseCase {
+
+    /**
+     * PolicyKey로 UploadPolicy를 조회합니다.
+     *
+     * @param policyKeyDto 조회할 정책의 키
+     * @return 조회된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 정책이 존재하지 않는 경우
+     */
+    UploadPolicyResponse getPolicy(PolicyKeyDto policyKeyDto);
+
+    /**
+     * PolicyKey로 활성화된 UploadPolicy를 조회합니다.
+     *
+     * @param policyKeyDto 조회할 정책의 키
+     * @return 활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 활성화된 정책이 존재하지 않는 경우
+     */
+    UploadPolicyResponse getActivePolicy(PolicyKeyDto policyKeyDto);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/in/UpdateUploadPolicyUseCase.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/in/UpdateUploadPolicyUseCase.java
@@ -1,0 +1,30 @@
+package com.ryuqq.fileflow.application.port.in;
+
+import com.ryuqq.fileflow.application.dto.UpdateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+
+/**
+ * UploadPolicy 업데이트 UseCase
+ *
+ * Hexagonal Architecture의 Inbound Port로서,
+ * 기존 UploadPolicy를 업데이트하는 비즈니스 로직을 정의합니다.
+ *
+ * 비즈니스 규칙:
+ * 1. 버전이 자동으로 1 증가
+ * 2. PolicyUpdatedEvent 발행
+ * 3. 정책이 존재하지 않으면 실패
+ *
+ * @author sangwon-ryu
+ */
+public interface UpdateUploadPolicyUseCase {
+
+    /**
+     * UploadPolicy를 업데이트합니다.
+     *
+     * @param command 정책 업데이트 Command
+     * @return 업데이트된 정책 Response
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException 정책이 존재하지 않는 경우
+     */
+    UploadPolicyResponse updatePolicy(UpdateUploadPolicyCommand command);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/out/DeleteUploadPolicyPort.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/out/DeleteUploadPolicyPort.java
@@ -1,0 +1,27 @@
+package com.ryuqq.fileflow.application.port.out;
+
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+
+/**
+ * UploadPolicy 삭제를 위한 Outbound Port
+ *
+ * Hexagonal Architecture의 Outbound Port로서,
+ * Application Layer가 UploadPolicy를 삭제하기 위한 인터페이스입니다.
+ *
+ * @author sangwon-ryu
+ */
+public interface DeleteUploadPolicyPort {
+
+    /**
+     * PolicyKey에 해당하는 UploadPolicy를 삭제합니다.
+     *
+     * 비즈니스 규칙:
+     * - 활성화된 정책은 삭제할 수 없습니다 (먼저 비활성화 필요)
+     * - PolicyKey에 해당하는 정책이 존재하지 않으면 예외를 발생시킵니다
+     *
+     * @param policyKey 삭제할 정책의 키
+     * @throws IllegalArgumentException policyKey가 null인 경우
+     * @throws IllegalStateException 정책이 활성화 상태인 경우 또는 존재하지 않는 경우
+     */
+    void delete(PolicyKey policyKey);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/out/LoadUploadPolicyPort.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/out/LoadUploadPolicyPort.java
@@ -1,0 +1,36 @@
+package com.ryuqq.fileflow.application.port.out;
+
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+
+import java.util.Optional;
+
+/**
+ * UploadPolicy 조회를 위한 Outbound Port
+ *
+ * Hexagonal Architecture의 Outbound Port로서,
+ * Application Layer가 외부 저장소(Database, Cache 등)로부터
+ * UploadPolicy를 조회하기 위한 인터페이스입니다.
+ *
+ * @author sangwon-ryu
+ */
+public interface LoadUploadPolicyPort {
+
+    /**
+     * PolicyKey로 UploadPolicy를 조회합니다.
+     *
+     * @param policyKey 조회할 정책의 키
+     * @return 조회된 UploadPolicy (존재하지 않으면 Optional.empty())
+     * @throws IllegalArgumentException policyKey가 null인 경우
+     */
+    Optional<UploadPolicy> loadByKey(PolicyKey policyKey);
+
+    /**
+     * PolicyKey로 활성화된 UploadPolicy를 조회합니다.
+     *
+     * @param policyKey 조회할 정책의 키
+     * @return 활성화된 UploadPolicy (존재하지 않거나 비활성화 상태면 Optional.empty())
+     * @throws IllegalArgumentException policyKey가 null인 경우
+     */
+    Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/out/SaveUploadPolicyPort.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/out/SaveUploadPolicyPort.java
@@ -1,0 +1,29 @@
+package com.ryuqq.fileflow.application.port.out;
+
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+
+/**
+ * UploadPolicy 저장을 위한 Outbound Port
+ *
+ * Hexagonal Architecture의 Outbound Port로서,
+ * Application Layer가 UploadPolicy를 외부 저장소에
+ * 저장하기 위한 인터페이스입니다.
+ *
+ * @author sangwon-ryu
+ */
+public interface SaveUploadPolicyPort {
+
+    /**
+     * UploadPolicy를 저장합니다.
+     *
+     * 비즈니스 규칙:
+     * - 동일한 PolicyKey를 가진 정책이 이미 존재하는 경우 예외를 발생시킵니다
+     * - 저장 성공 시 저장된 정책을 반환합니다
+     *
+     * @param uploadPolicy 저장할 UploadPolicy
+     * @return 저장된 UploadPolicy
+     * @throws IllegalArgumentException uploadPolicy가 null인 경우
+     * @throws IllegalStateException 동일한 PolicyKey를 가진 정책이 이미 존재하는 경우
+     */
+    UploadPolicy save(UploadPolicy uploadPolicy);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/port/out/UpdateUploadPolicyPort.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/port/out/UpdateUploadPolicyPort.java
@@ -1,0 +1,28 @@
+package com.ryuqq.fileflow.application.port.out;
+
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+
+/**
+ * UploadPolicy 업데이트를 위한 Outbound Port
+ *
+ * Hexagonal Architecture의 Outbound Port로서,
+ * Application Layer가 기존 UploadPolicy를 업데이트하기 위한 인터페이스입니다.
+ *
+ * @author sangwon-ryu
+ */
+public interface UpdateUploadPolicyPort {
+
+    /**
+     * UploadPolicy를 업데이트합니다.
+     *
+     * 비즈니스 규칙:
+     * - PolicyKey에 해당하는 정책이 존재하지 않으면 예외를 발생시킵니다
+     * - 업데이트 성공 시 업데이트된 정책을 반환합니다
+     *
+     * @param uploadPolicy 업데이트할 UploadPolicy
+     * @return 업데이트된 UploadPolicy
+     * @throws IllegalArgumentException uploadPolicy가 null인 경우
+     * @throws IllegalStateException PolicyKey에 해당하는 정책이 존재하지 않는 경우
+     */
+    UploadPolicy update(UploadPolicy uploadPolicy);
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/ActivateUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/ActivateUploadPolicyService.java
@@ -1,0 +1,73 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.in.ActivateUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 활성화 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 활성화 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class ActivateUploadPolicyService implements ActivateUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+    private final UpdateUploadPolicyPort updateUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     * @param updateUploadPolicyPort 정책 업데이트 Port
+     */
+    public ActivateUploadPolicyService(
+            LoadUploadPolicyPort loadUploadPolicyPort,
+            UpdateUploadPolicyPort updateUploadPolicyPort
+    ) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+        this.updateUploadPolicyPort = Objects.requireNonNull(updateUploadPolicyPort, "UpdateUploadPolicyPort must not be null");
+    }
+
+    /**
+     * UploadPolicy를 활성화합니다.
+     *
+     * 비즈니스 로직:
+     * 1. 기존 정책 조회
+     * 2. 도메인 정책 활성화 (이벤트 발행)
+     * 3. 활성화된 정책 저장
+     *
+     * @param policyKeyDto 활성화할 정책의 키
+     * @return 활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 이미 활성화된 경우
+     */
+    @Override
+    public UploadPolicyResponse activatePolicy(PolicyKeyDto policyKeyDto) {
+        Objects.requireNonNull(policyKeyDto, "PolicyKeyDto must not be null");
+
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        // 1. 기존 정책 조회
+        UploadPolicy existingPolicy = loadUploadPolicyPort.loadByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        // 2. 도메인 정책 활성화
+        UploadPolicy activatedPolicy = existingPolicy.activate();
+
+        // 3. 활성화된 정책 저장
+        UploadPolicy savedPolicy = updateUploadPolicyPort.update(activatedPolicy);
+
+        return UploadPolicyResponse.from(savedPolicy);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/CreateUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/CreateUploadPolicyService.java
@@ -1,0 +1,78 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.CreateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.in.CreateUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.SaveUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 생성 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 생성 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class CreateUploadPolicyService implements CreateUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+    private final SaveUploadPolicyPort saveUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     * @param saveUploadPolicyPort 정책 저장 Port
+     */
+    public CreateUploadPolicyService(
+            LoadUploadPolicyPort loadUploadPolicyPort,
+            SaveUploadPolicyPort saveUploadPolicyPort
+    ) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+        this.saveUploadPolicyPort = Objects.requireNonNull(saveUploadPolicyPort, "SaveUploadPolicyPort must not be null");
+    }
+
+    /**
+     * 새로운 UploadPolicy를 생성합니다.
+     *
+     * 비즈니스 로직:
+     * 1. 동일한 PolicyKey를 가진 정책이 이미 존재하는지 확인
+     * 2. UploadPolicy 도메인 객체 생성
+     * 3. 정책 저장
+     *
+     * @param command 정책 생성 Command
+     * @return 생성된 정책 Response
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws IllegalStateException 동일한 PolicyKey를 가진 정책이 이미 존재하는 경우
+     */
+    @Override
+    public UploadPolicyResponse createPolicy(CreateUploadPolicyCommand command) {
+        Objects.requireNonNull(command, "CreateUploadPolicyCommand must not be null");
+
+        PolicyKey policyKey = command.getPolicyKey();
+
+        // 1. 중복 정책 확인
+        loadUploadPolicyPort.loadByKey(policyKey).ifPresent(existing -> {
+            throw new IllegalStateException("Policy already exists with key: " + policyKey.getValue());
+        });
+
+        // 2. UploadPolicy 생성
+        UploadPolicy uploadPolicy = UploadPolicy.create(
+                policyKey,
+                command.getFileTypePolicies(),
+                command.getRateLimiting(),
+                command.effectiveFrom(),
+                command.effectiveUntil()
+        );
+
+        // 3. 정책 저장
+        UploadPolicy savedPolicy = saveUploadPolicyPort.save(uploadPolicy);
+
+        return UploadPolicyResponse.from(savedPolicy);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/DeactivateUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/DeactivateUploadPolicyService.java
@@ -1,0 +1,73 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.in.DeactivateUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 비활성화 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 비활성화 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class DeactivateUploadPolicyService implements DeactivateUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+    private final UpdateUploadPolicyPort updateUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     * @param updateUploadPolicyPort 정책 업데이트 Port
+     */
+    public DeactivateUploadPolicyService(
+            LoadUploadPolicyPort loadUploadPolicyPort,
+            UpdateUploadPolicyPort updateUploadPolicyPort
+    ) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+        this.updateUploadPolicyPort = Objects.requireNonNull(updateUploadPolicyPort, "UpdateUploadPolicyPort must not be null");
+    }
+
+    /**
+     * UploadPolicy를 비활성화합니다.
+     *
+     * 비즈니스 로직:
+     * 1. 기존 정책 조회
+     * 2. 도메인 정책 비활성화
+     * 3. 비활성화된 정책 저장
+     *
+     * @param policyKeyDto 비활성화할 정책의 키
+     * @return 비활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 이미 비활성화된 경우
+     */
+    @Override
+    public UploadPolicyResponse deactivatePolicy(PolicyKeyDto policyKeyDto) {
+        Objects.requireNonNull(policyKeyDto, "PolicyKeyDto must not be null");
+
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        // 1. 기존 정책 조회
+        UploadPolicy existingPolicy = loadUploadPolicyPort.loadByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        // 2. 도메인 정책 비활성화
+        UploadPolicy deactivatedPolicy = existingPolicy.deactivate();
+
+        // 3. 비활성화된 정책 저장
+        UploadPolicy savedPolicy = updateUploadPolicyPort.update(deactivatedPolicy);
+
+        return UploadPolicyResponse.from(savedPolicy);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/DeleteUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/DeleteUploadPolicyService.java
@@ -1,0 +1,71 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.port.in.DeleteUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.DeleteUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 삭제 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 삭제 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class DeleteUploadPolicyService implements DeleteUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+    private final DeleteUploadPolicyPort deleteUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     * @param deleteUploadPolicyPort 정책 삭제 Port
+     */
+    public DeleteUploadPolicyService(
+            LoadUploadPolicyPort loadUploadPolicyPort,
+            DeleteUploadPolicyPort deleteUploadPolicyPort
+    ) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+        this.deleteUploadPolicyPort = Objects.requireNonNull(deleteUploadPolicyPort, "DeleteUploadPolicyPort must not be null");
+    }
+
+    /**
+     * UploadPolicy를 삭제합니다.
+     *
+     * 비즈니스 로직:
+     * 1. 기존 정책 조회
+     * 2. 활성 상태 검증 (활성화된 정책은 삭제 불가)
+     * 3. 정책 삭제
+     *
+     * @param policyKeyDto 삭제할 정책의 키
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws PolicyNotFoundException 정책이 존재하지 않는 경우
+     * @throws IllegalStateException 정책이 활성화 상태인 경우
+     */
+    @Override
+    public void deletePolicy(PolicyKeyDto policyKeyDto) {
+        Objects.requireNonNull(policyKeyDto, "PolicyKeyDto must not be null");
+
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        // 1. 기존 정책 조회
+        UploadPolicy existingPolicy = loadUploadPolicyPort.loadByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        // 2. 활성 상태 검증
+        if (existingPolicy.isActive()) {
+            throw new IllegalStateException("Cannot delete active policy. Deactivate it first: " + policyKey.getValue());
+        }
+
+        // 3. 정책 삭제
+        deleteUploadPolicyPort.delete(policyKey);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/GetUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/GetUploadPolicyService.java
@@ -1,0 +1,73 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.in.GetUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 조회 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 조회 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class GetUploadPolicyService implements GetUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     */
+    public GetUploadPolicyService(LoadUploadPolicyPort loadUploadPolicyPort) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+    }
+
+    /**
+     * PolicyKey로 UploadPolicy를 조회합니다.
+     *
+     * @param policyKeyDto 조회할 정책의 키
+     * @return 조회된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws PolicyNotFoundException 정책이 존재하지 않는 경우
+     */
+    @Override
+    public UploadPolicyResponse getPolicy(PolicyKeyDto policyKeyDto) {
+        Objects.requireNonNull(policyKeyDto, "PolicyKeyDto must not be null");
+
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy uploadPolicy = loadUploadPolicyPort.loadByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        return UploadPolicyResponse.from(uploadPolicy);
+    }
+
+    /**
+     * PolicyKey로 활성화된 UploadPolicy를 조회합니다.
+     *
+     * @param policyKeyDto 조회할 정책의 키
+     * @return 활성화된 정책 Response
+     * @throws IllegalArgumentException policyKeyDto가 null인 경우
+     * @throws PolicyNotFoundException 활성화된 정책이 존재하지 않는 경우
+     */
+    @Override
+    public UploadPolicyResponse getActivePolicy(PolicyKeyDto policyKeyDto) {
+        Objects.requireNonNull(policyKeyDto, "PolicyKeyDto must not be null");
+
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy uploadPolicy = loadUploadPolicyPort.loadActiveByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        return UploadPolicyResponse.from(uploadPolicy);
+    }
+}

--- a/application/src/main/java/com/ryuqq/fileflow/application/service/UpdateUploadPolicyService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/service/UpdateUploadPolicyService.java
@@ -1,0 +1,75 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.UpdateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.in.UpdateUploadPolicyUseCase;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+
+import java.util.Objects;
+
+/**
+ * UploadPolicy 업데이트 Service
+ *
+ * Hexagonal Architecture의 UseCase 구현체로서,
+ * UploadPolicy 업데이트 비즈니스 로직을 처리합니다.
+ *
+ * @author sangwon-ryu
+ */
+public class UpdateUploadPolicyService implements UpdateUploadPolicyUseCase {
+
+    private final LoadUploadPolicyPort loadUploadPolicyPort;
+    private final UpdateUploadPolicyPort updateUploadPolicyPort;
+
+    /**
+     * Constructor Injection (NO Lombok)
+     *
+     * @param loadUploadPolicyPort 정책 조회 Port
+     * @param updateUploadPolicyPort 정책 업데이트 Port
+     */
+    public UpdateUploadPolicyService(
+            LoadUploadPolicyPort loadUploadPolicyPort,
+            UpdateUploadPolicyPort updateUploadPolicyPort
+    ) {
+        this.loadUploadPolicyPort = Objects.requireNonNull(loadUploadPolicyPort, "LoadUploadPolicyPort must not be null");
+        this.updateUploadPolicyPort = Objects.requireNonNull(updateUploadPolicyPort, "UpdateUploadPolicyPort must not be null");
+    }
+
+    /**
+     * UploadPolicy를 업데이트합니다.
+     *
+     * 비즈니스 로직:
+     * 1. 기존 정책 조회
+     * 2. 도메인 정책 업데이트 (버전 자동 증가 + 이벤트 발행)
+     * 3. 업데이트된 정책 저장
+     *
+     * @param command 정책 업데이트 Command
+     * @return 업데이트된 정책 Response
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws PolicyNotFoundException 정책이 존재하지 않는 경우
+     */
+    @Override
+    public UploadPolicyResponse updatePolicy(UpdateUploadPolicyCommand command) {
+        Objects.requireNonNull(command, "UpdateUploadPolicyCommand must not be null");
+
+        PolicyKey policyKey = command.getPolicyKey();
+
+        // 1. 기존 정책 조회
+        UploadPolicy existingPolicy = loadUploadPolicyPort.loadByKey(policyKey)
+                .orElseThrow(() -> new PolicyNotFoundException(policyKey.getValue()));
+
+        // 2. 도메인 정책 업데이트 (버전 증가 + 이벤트 발행)
+        UploadPolicy updatedPolicy = existingPolicy.updatePolicy(
+                command.getFileTypePolicies(),
+                command.changedBy()
+        );
+
+        // 3. 업데이트된 정책 저장
+        UploadPolicy savedPolicy = updateUploadPolicyPort.update(updatedPolicy);
+
+        return UploadPolicyResponse.from(savedPolicy);
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/ActivateUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/ActivateUploadPolicyServiceTest.java
@@ -1,0 +1,124 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ActivateUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class ActivateUploadPolicyServiceTest {
+
+    private ActivateUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+    private TestUpdateUploadPolicyPort updatePort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        updatePort = new TestUpdateUploadPolicyPort();
+        service = new ActivateUploadPolicyService(loadPort, updatePort);
+    }
+
+    @Test
+    @DisplayName("정책 활성화 성공")
+    void activatePolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+        loadPort.setPolicy(policy);
+
+        // When
+        UploadPolicyResponse response = service.activatePolicy(policyKeyDto);
+
+        // Then
+        assertNotNull(response);
+        assertTrue(response.isActive());
+    }
+
+    @Test
+    @DisplayName("정책 활성화 실패 - 정책 없음")
+    void activatePolicy_notFound_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+
+        // When & Then
+        assertThrows(PolicyNotFoundException.class, () -> service.activatePolicy(policyKeyDto));
+    }
+
+    @Test
+    @DisplayName("이미 활성화된 정책 재활성화 시 예외 발생")
+    void activatePolicy_alreadyActive_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        ).activate();
+        loadPort.setPolicy(policy);
+
+        // When & Then
+        assertThrows(IllegalStateException.class, () -> service.activatePolicy(policyKeyDto));
+    }
+
+    // Test Doubles
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            return Optional.empty();
+        }
+    }
+
+    static class TestUpdateUploadPolicyPort implements UpdateUploadPolicyPort {
+        @Override
+        public UploadPolicy update(UploadPolicy uploadPolicy) {
+            return uploadPolicy;
+        }
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/CreateUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/CreateUploadPolicyServiceTest.java
@@ -1,0 +1,142 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.CreateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.SaveUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * CreateUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class CreateUploadPolicyServiceTest {
+
+    private CreateUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+    private TestSaveUploadPolicyPort savePort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        savePort = new TestSaveUploadPolicyPort();
+        service = new CreateUploadPolicyService(loadPort, savePort);
+    }
+
+    @Test
+    @DisplayName("정책 생성 성공")
+    void createPolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        ImagePolicy imagePolicy = ImagePolicy.createDefault();
+        CreateUploadPolicyCommand command = new CreateUploadPolicyCommand(
+                policyKeyDto,
+                imagePolicy,
+                null,
+                null,
+                null,
+                100,
+                1000,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+
+        // When
+        UploadPolicyResponse response = service.createPolicy(command);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("b2c:CONSUMER:REVIEW", response.policyKey());
+        assertEquals(1, response.version());
+        assertFalse(response.isActive());
+    }
+
+    @Test
+    @DisplayName("중복 정책 생성 시 예외 발생")
+    void createPolicy_duplicateKey_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+        ImagePolicy imagePolicy = ImagePolicy.createDefault();
+
+        // 기존 정책 설정
+        UploadPolicy existingPolicy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(imagePolicy, null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+        loadPort.setPolicy(existingPolicy);
+
+        CreateUploadPolicyCommand command = new CreateUploadPolicyCommand(
+                policyKeyDto,
+                imagePolicy,
+                null,
+                null,
+                null,
+                100,
+                1000,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+
+        // When & Then
+        assertThrows(IllegalStateException.class, () -> service.createPolicy(command));
+    }
+
+    @Test
+    @DisplayName("null command 전달 시 예외 발생")
+    void createPolicy_nullCommand_throwsException() {
+        assertThrows(NullPointerException.class, () -> service.createPolicy(null));
+    }
+
+    // Test Doubles
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey) && policy.isActive()) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+    }
+
+    static class TestSaveUploadPolicyPort implements SaveUploadPolicyPort {
+        @Override
+        public UploadPolicy save(UploadPolicy uploadPolicy) {
+            return uploadPolicy;
+        }
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/DeactivateUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/DeactivateUploadPolicyServiceTest.java
@@ -1,0 +1,104 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * DeactivateUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class DeactivateUploadPolicyServiceTest {
+
+    private DeactivateUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+    private TestUpdateUploadPolicyPort updatePort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        updatePort = new TestUpdateUploadPolicyPort();
+        service = new DeactivateUploadPolicyService(loadPort, updatePort);
+    }
+
+    @Test
+    @DisplayName("정책 비활성화 성공")
+    void deactivatePolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        ).activate();
+        loadPort.setPolicy(policy);
+
+        // When
+        UploadPolicyResponse response = service.deactivatePolicy(policyKeyDto);
+
+        // Then
+        assertNotNull(response);
+        assertFalse(response.isActive());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정책 비활성화 시 예외 발생")
+    void deactivatePolicy_notFound_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+
+        // When & Then
+        assertThrows(PolicyNotFoundException.class, () -> service.deactivatePolicy(policyKeyDto));
+    }
+
+    // Test Doubles
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            return Optional.empty();
+        }
+    }
+
+    static class TestUpdateUploadPolicyPort implements UpdateUploadPolicyPort {
+        @Override
+        public UploadPolicy update(UploadPolicy uploadPolicy) {
+            return uploadPolicy;
+        }
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/DeleteUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/DeleteUploadPolicyServiceTest.java
@@ -1,0 +1,118 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.port.out.DeleteUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * DeleteUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class DeleteUploadPolicyServiceTest {
+
+    private DeleteUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+    private TestDeleteUploadPolicyPort deletePort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        deletePort = new TestDeleteUploadPolicyPort();
+        service = new DeleteUploadPolicyService(loadPort, deletePort);
+    }
+
+    @Test
+    @DisplayName("비활성 정책 삭제 성공")
+    void deletePolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+        loadPort.setPolicy(policy);
+
+        // When & Then
+        assertDoesNotThrow(() -> service.deletePolicy(policyKeyDto));
+    }
+
+    @Test
+    @DisplayName("활성 정책 삭제 시 예외 발생")
+    void deletePolicy_activePolicy_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        ).activate();
+        loadPort.setPolicy(policy);
+
+        // When & Then
+        assertThrows(IllegalStateException.class, () -> service.deletePolicy(policyKeyDto));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정책 삭제 시 예외 발생")
+    void deletePolicy_notFound_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+
+        // When & Then
+        assertThrows(PolicyNotFoundException.class, () -> service.deletePolicy(policyKeyDto));
+    }
+
+    // Test Doubles
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            return Optional.empty();
+        }
+    }
+
+    static class TestDeleteUploadPolicyPort implements DeleteUploadPolicyPort {
+        @Override
+        public void delete(PolicyKey policyKey) {
+            // 삭제 성공
+        }
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/GetUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/GetUploadPolicyServiceTest.java
@@ -1,0 +1,128 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * GetUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class GetUploadPolicyServiceTest {
+
+    private GetUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        service = new GetUploadPolicyService(loadPort);
+    }
+
+    @Test
+    @DisplayName("정책 조회 성공")
+    void getPolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+        loadPort.setPolicy(policy);
+
+        // When
+        UploadPolicyResponse response = service.getPolicy(policyKeyDto);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("b2c:CONSUMER:REVIEW", response.policyKey());
+    }
+
+    @Test
+    @DisplayName("정책 조회 실패 - 정책 없음")
+    void getPolicy_notFound_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+
+        // When & Then
+        assertThrows(PolicyNotFoundException.class, () -> service.getPolicy(policyKeyDto));
+    }
+
+    @Test
+    @DisplayName("활성 정책 조회 성공")
+    void getActivePolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy policy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        ).activate();
+        loadPort.setPolicy(policy);
+
+        // When
+        UploadPolicyResponse response = service.getActivePolicy(policyKeyDto);
+
+        // Then
+        assertNotNull(response);
+        assertTrue(response.isActive());
+    }
+
+    @Test
+    @DisplayName("null policyKeyDto 전달 시 예외 발생")
+    void getPolicy_nullDto_throwsException() {
+        assertThrows(NullPointerException.class, () -> service.getPolicy(null));
+    }
+
+    // Test Double
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey) && policy.isActive()) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/application/src/test/java/com/ryuqq/fileflow/application/service/UpdateUploadPolicyServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/service/UpdateUploadPolicyServiceTest.java
@@ -1,0 +1,122 @@
+package com.ryuqq.fileflow.application.service;
+
+import com.ryuqq.fileflow.application.dto.PolicyKeyDto;
+import com.ryuqq.fileflow.application.dto.UpdateUploadPolicyCommand;
+import com.ryuqq.fileflow.application.dto.UploadPolicyResponse;
+import com.ryuqq.fileflow.application.port.out.LoadUploadPolicyPort;
+import com.ryuqq.fileflow.application.port.out.UpdateUploadPolicyPort;
+import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.policy.UploadPolicy;
+import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
+import com.ryuqq.fileflow.domain.policy.vo.FileTypePolicies;
+import com.ryuqq.fileflow.domain.policy.vo.ImagePolicy;
+import com.ryuqq.fileflow.domain.policy.vo.RateLimiting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * UpdateUploadPolicyService 단위 테스트
+ *
+ * @author sangwon-ryu
+ */
+class UpdateUploadPolicyServiceTest {
+
+    private UpdateUploadPolicyService service;
+    private TestLoadUploadPolicyPort loadPort;
+    private TestUpdateUploadPolicyPort updatePort;
+
+    @BeforeEach
+    void setUp() {
+        loadPort = new TestLoadUploadPolicyPort();
+        updatePort = new TestUpdateUploadPolicyPort();
+        service = new UpdateUploadPolicyService(loadPort, updatePort);
+    }
+
+    @Test
+    @DisplayName("정책 업데이트 성공")
+    void updatePolicy_success() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        PolicyKey policyKey = policyKeyDto.toDomain();
+
+        UploadPolicy existingPolicy = UploadPolicy.create(
+                policyKey,
+                FileTypePolicies.of(ImagePolicy.createDefault(), null, null, null),
+                new RateLimiting(100, 1000),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+        loadPort.setPolicy(existingPolicy);
+
+        UpdateUploadPolicyCommand command = new UpdateUploadPolicyCommand(
+                policyKeyDto,
+                ImagePolicy.createDefault(),
+                null,
+                null,
+                null,
+                "admin"
+        );
+
+        // When
+        UploadPolicyResponse response = service.updatePolicy(command);
+
+        // Then
+        assertNotNull(response);
+        assertEquals(2, response.version()); // 버전 증가 확인
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정책 업데이트 시 예외 발생")
+    void updatePolicy_notFound_throwsException() {
+        // Given
+        PolicyKeyDto policyKeyDto = new PolicyKeyDto("b2c", "CONSUMER", "REVIEW");
+        UpdateUploadPolicyCommand command = new UpdateUploadPolicyCommand(
+                policyKeyDto,
+                ImagePolicy.createDefault(),
+                null,
+                null,
+                null,
+                "admin"
+        );
+
+        // When & Then
+        assertThrows(PolicyNotFoundException.class, () -> service.updatePolicy(command));
+    }
+
+    // Test Doubles
+    static class TestLoadUploadPolicyPort implements LoadUploadPolicyPort {
+        private UploadPolicy policy;
+
+        void setPolicy(UploadPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadByKey(PolicyKey policyKey) {
+            if (policy != null && policy.getPolicyKey().equals(policyKey)) {
+                return Optional.of(policy);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UploadPolicy> loadActiveByKey(PolicyKey policyKey) {
+            return Optional.empty();
+        }
+    }
+
+    static class TestUpdateUploadPolicyPort implements UpdateUploadPolicyPort {
+        @Override
+        public UploadPolicy update(UploadPolicy uploadPolicy) {
+            return uploadPolicy;
+        }
+    }
+}

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -9,7 +9,19 @@
 
 set -e  # Exit on first error
 
-HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlink for macOS compatibility
+if [ -L "${BASH_SOURCE[0]}" ]; then
+    # Follow symlink
+    HOOK_SCRIPT="$(readlink "${BASH_SOURCE[0]}")"
+    if [[ "$HOOK_SCRIPT" != /* ]]; then
+        # Relative path, resolve it
+        HOOK_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(dirname "$HOOK_SCRIPT")" && pwd)/$(basename "$HOOK_SCRIPT")"
+    fi
+else
+    HOOK_SCRIPT="${BASH_SOURCE[0]}"
+fi
+
+HOOKS_DIR="$(cd "$(dirname "$HOOK_SCRIPT")" && pwd)"
 VALIDATORS_DIR="$HOOKS_DIR/validators"
 PROJECT_ROOT="$(cd "$HOOKS_DIR/.." && pwd)"
 


### PR DESCRIPTION
## 📋 Summary
KAN-3 Task 1.2: Port & UseCase 구현 완료

헥사고날 아키텍처를 따라 Application Layer 구현을 완료했습니다.

## 🎯 Implementation Details

### Outbound Ports (4)
- `LoadUploadPolicyPort`: 정책 조회 인터페이스
- `SaveUploadPolicyPort`: 정책 생성 인터페이스
- `UpdateUploadPolicyPort`: 정책 수정 인터페이스
- `DeleteUploadPolicyPort`: 정책 삭제 인터페이스

### Inbound Ports - UseCases (6)
- `CreateUploadPolicyUseCase`: 새 정책 생성
- `GetUploadPolicyUseCase`: 정책 키로 조회
- `UpdateUploadPolicyUseCase`: 기존 정책 수정
- `ActivateUploadPolicyUseCase`: 정책 활성화
- `DeactivateUploadPolicyUseCase`: 정책 비활성화
- `DeleteUploadPolicyUseCase`: 비활성 정책 삭제

### Service Implementations (6)
각 UseCase에 대한 서비스 구현 완료:
- 비즈니스 로직 구현
- 적절한 예외 처리 및 검증
- NO Lombok, 생성자 주입만 사용
- 80%+ 테스트 커버리지 달성

### DTOs (4)
- `PolicyKeyDto`: 정책 키 전송 객체
- `CreateUploadPolicyCommand`: 정책 생성 명령
- `UpdateUploadPolicyCommand`: 정책 수정 명령
- `UploadPolicyResponse`: 정책 응답 객체

## ✅ Technical Details
- Checkstyle 규칙 준수 (star import 제거)
- @author 태그가 포함된 Javadoc
- 불변성을 위한 Record 기반 DTO
- Port 구현을 위한 Test Double 사용
- 모든 단위 테스트 통과

## 🧪 Test Plan
- [x] 6개의 Service 단위 테스트 작성
- [x] 각 UseCase별 성공/실패 시나리오 테스트
- [x] 80%+ 코드 커버리지 달성
- [x] Checkstyle 검증 통과
- [x] 빌드 성공

## 📊 Coverage
Application 모듈: 80%+

🤖 Generated with [Claude Code](https://claude.com/claude-code)