### PR TITLE
refactor(domain): Epic 1 정책 검증 통합 보완 (KAN-12)

### DIFF
--- a/adapter/adapter-in-rest-api/src/main/java/com/ryuqq/fileflow/adapter/rest/dto/response/PolicyViolationErrorResponse.java
+++ b/adapter/adapter-in-rest-api/src/main/java/com/ryuqq/fileflow/adapter/rest/dto/response/PolicyViolationErrorResponse.java
@@ -1,0 +1,81 @@
+package com.ryuqq.fileflow.adapter.rest.dto.response;
+
+import com.ryuqq.fileflow.domain.policy.exception.PolicyViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * Policy Violation Error Response DTO
+ *
+ * 정책 위반 시 상세한 에러 정보를 제공하는 DTO
+ *
+ * @param timestamp 에러 발생 시각
+ * @param status HTTP 상태 코드
+ * @param error 에러 타입 (POLICY_VIOLATION)
+ * @param message 사용자 친화적 에러 메시지
+ * @param details 상세 정보 (위반된 정책 값들)
+ * @param path 요청 경로
+ * @author sangwon-ryu
+ */
+public record PolicyViolationErrorResponse(
+        LocalDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        Map<String, Object> details,
+        String path
+) {
+    /**
+     * PolicyViolationException으로부터 응답 생성
+     *
+     * @param ex PolicyViolationException
+     * @param path 요청 경로
+     * @return PolicyViolationErrorResponse
+     */
+    public static PolicyViolationErrorResponse from(PolicyViolationException ex, String path) {
+        return new PolicyViolationErrorResponse(
+                LocalDateTime.now(),
+                400,
+                ex.getViolationType().name(),
+                convertToUserFriendlyMessage(ex.getViolationType(), ex.getDetails()),
+                parseDetails(ex.getDetails()),
+                path
+        );
+    }
+
+    /**
+     * ViolationType에 따라 사용자 친화적 메시지 생성
+     *
+     * @param violationType 위반 타입
+     * @param details 상세 정보
+     * @return 사용자 친화적 메시지
+     */
+    private static String convertToUserFriendlyMessage(
+            PolicyViolationException.ViolationType violationType,
+            String details
+    ) {
+        return switch (violationType) {
+            case FILE_SIZE_EXCEEDED -> "파일 크기가 정책 허용 범위를 초과했습니다";
+            case FILE_COUNT_EXCEEDED -> "파일 개수가 정책 허용 범위를 초과했습니다";
+            case INVALID_FORMAT -> "허용되지 않은 파일 형식입니다";
+            case DIMENSION_EXCEEDED -> "이미지 크기가 정책 허용 범위를 초과했습니다";
+            case RATE_LIMIT_EXCEEDED -> "요청 제한을 초과했습니다";
+        };
+    }
+
+    /**
+     * details 문자열을 Map으로 파싱
+     *
+     * 현재는 details를 그대로 반환하지만,
+     * 향후 구조화된 정보로 확장 가능
+     *
+     * @param details 상세 정보 문자열
+     * @return 상세 정보 Map
+     */
+    private static Map<String, Object> parseDetails(String details) {
+        // 현재는 단순히 details 문자열을 반환
+        // 향후 PolicyViolationException에서 구조화된 정보를 제공하면 파싱 로직 추가
+        return Map.of("rawDetails", details);
+    }
+}

--- a/adapter/adapter-in-rest-api/src/main/java/com/ryuqq/fileflow/adapter/rest/exception/GlobalExceptionHandler.java
+++ b/adapter/adapter-in-rest-api/src/main/java/com/ryuqq/fileflow/adapter/rest/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ryuqq.fileflow.adapter.rest.exception;
 
 import com.ryuqq.fileflow.adapter.rest.dto.response.ErrorResponse;
+import com.ryuqq.fileflow.adapter.rest.dto.response.PolicyViolationErrorResponse;
 import com.ryuqq.fileflow.domain.policy.exception.InvalidPolicyException;
 import com.ryuqq.fileflow.domain.policy.exception.PolicyNotFoundException;
 import com.ryuqq.fileflow.domain.policy.exception.PolicyViolationException;
@@ -75,19 +76,20 @@ public class GlobalExceptionHandler {
     /**
      * PolicyViolationException 처리
      *
+     * 표준화된 정책 위반 에러 응답을 반환합니다.
+     * 에러 타입, 사용자 친화적 메시지, 상세 정보를 포함합니다.
+     *
      * @param ex PolicyViolationException
      * @param request HttpServletRequest
      * @return 400 BAD_REQUEST 응답
      */
     @ExceptionHandler(PolicyViolationException.class)
-    public ResponseEntity<ErrorResponse> handlePolicyViolationException(
+    public ResponseEntity<PolicyViolationErrorResponse> handlePolicyViolationException(
             PolicyViolationException ex,
             HttpServletRequest request
     ) {
-        ErrorResponse errorResponse = ErrorResponse.of(
-                HttpStatus.BAD_REQUEST.value(),
-                "Policy Violation",
-                ex.getMessage(),
+        PolicyViolationErrorResponse errorResponse = PolicyViolationErrorResponse.from(
+                ex,
                 request.getRequestURI()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);

--- a/application/src/main/java/com/ryuqq/fileflow/application/upload/service/UploadSessionService.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/upload/service/UploadSessionService.java
@@ -14,6 +14,7 @@ import com.ryuqq.fileflow.domain.policy.FileType;
 import com.ryuqq.fileflow.domain.policy.PolicyKey;
 import com.ryuqq.fileflow.domain.upload.command.FileUploadCommand;
 import com.ryuqq.fileflow.domain.upload.exception.UploadSessionNotFoundException;
+import com.ryuqq.fileflow.domain.upload.vo.IdempotencyKey;
 import com.ryuqq.fileflow.domain.upload.vo.PresignedUrlInfo;
 import com.ryuqq.fileflow.domain.upload.vo.UploadRequest;
 import com.ryuqq.fileflow.domain.upload.UploadSession;
@@ -111,7 +112,8 @@ public class UploadSessionService implements
                 command.fileName(),
                 fileType,
                 command.fileSize(),
-                command.contentType()
+                command.contentType(),
+                IdempotencyKey.generate()
         );
 
         // 4. UploadSession 생성

--- a/application/src/test/java/com/ryuqq/fileflow/application/policy/service/UploadPolicyValidationServiceTest.java
+++ b/application/src/test/java/com/ryuqq/fileflow/application/policy/service/UploadPolicyValidationServiceTest.java
@@ -157,6 +157,35 @@ class UploadPolicyValidationServiceTest {
         }
 
         @Test
+        @DisplayName("허용되지 않은 파일 형식 시 PolicyViolationException 발생")
+        void validateUploadPolicy_invalidFileFormat() {
+            // Given
+            PolicyKey policyKey = PolicyKey.of("b2c", "CONSUMER", "REVIEW");
+            UploadPolicy policy = createActivePolicy(policyKey);
+            loadPort.save(policy);
+
+            ValidateUploadPolicyCommand command = new ValidateUploadPolicyCommand(
+                    "b2c",
+                    "CONSUMER",
+                    "REVIEW",
+                    FileType.IMAGE,
+                    "bmp", // Not allowed (allowed: jpg, jpeg, png)
+                    5_000_000L,
+                    3,
+                    null,
+                    null
+            );
+
+            // When & Then
+            PolicyViolationException exception = assertThrows(
+                    PolicyViolationException.class,
+                    () -> service.validate(command)
+            );
+
+            assertEquals(PolicyViolationException.ViolationType.INVALID_FORMAT, exception.getViolationType());
+        }
+
+        @Test
         @DisplayName("비활성화된 정책은 검증 실패")
         void validateUploadPolicy_inactivePolicy() {
             // Given

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/policy/UploadPolicy.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/policy/UploadPolicy.java
@@ -158,7 +158,7 @@ public final class UploadPolicy {
             fileTypePolicies.validate(fileType, attributes);
         } catch (IllegalArgumentException e) {
             throw new PolicyViolationException(
-                    ViolationType.FILE_SIZE_EXCEEDED,
+                    determineViolationType(e.getMessage()),
                     e.getMessage()
             );
         }
@@ -374,6 +374,36 @@ public final class UploadPolicy {
         if (changedBy == null || changedBy.trim().isEmpty()) {
             throw new IllegalArgumentException("ChangedBy cannot be null or empty");
         }
+    }
+
+    /**
+     * 예외 메시지를 기반으로 적절한 ViolationType을 결정합니다.
+     *
+     * @param errorMessage 예외 메시지
+     * @return ViolationType
+     */
+    private static ViolationType determineViolationType(String errorMessage) {
+        if (errorMessage == null) {
+            return ViolationType.FILE_SIZE_EXCEEDED;
+        }
+
+        String lowerMessage = errorMessage.toLowerCase();
+
+        if (lowerMessage.contains("format not allowed") || lowerMessage.contains("format cannot")) {
+            return ViolationType.INVALID_FORMAT;
+        }
+        if (lowerMessage.contains("file size exceeds") || lowerMessage.contains("size exceeds")) {
+            return ViolationType.FILE_SIZE_EXCEEDED;
+        }
+        if (lowerMessage.contains("file count exceeds") || lowerMessage.contains("count exceeds")) {
+            return ViolationType.FILE_COUNT_EXCEEDED;
+        }
+        if (lowerMessage.contains("dimension exceeds") || lowerMessage.contains("image dimension")) {
+            return ViolationType.DIMENSION_EXCEEDED;
+        }
+
+        // 기본값
+        return ViolationType.FILE_SIZE_EXCEEDED;
     }
 
     // ========== Domain Events ==========


### PR DESCRIPTION
## 📋 Summary

Epic 1에서 구현한 정책 검증 로직을 파일 업로드 흐름에 통합하고, Jira 태스크에서 요구한 보완 사항을 완료했습니다.

## 🎯 주요 변경사항

### 1. 정책 위반 타입 판별 로직 개선
- `UploadPolicy.determineViolationType()` 메서드 추가
- 예외 메시지 기반 ViolationType 자동 판별
- INVALID_FORMAT, FILE_SIZE_EXCEEDED, FILE_COUNT_EXCEEDED, DIMENSION_EXCEEDED 구분

### 2. 에러 응답 표준화
- `PolicyViolationErrorResponse` DTO 신규 생성
- ViolationType별 사용자 친화적 메시지 제공
- GlobalExceptionHandler에 PolicyViolationException 전용 핸들러 적용

**에러 응답 형식**:
```json
{
  "timestamp": "2025-10-08T10:28:11",
  "status": 400,
  "error": "FILE_SIZE_EXCEEDED",
  "message": "파일 크기가 정책 허용 범위를 초과했습니다",
  "details": {
    "rawDetails": "File size exceeds limit: 15000000 bytes. Max allowed: 10485760 bytes"
  },
  "path": "/api/upload"
}
```

### 3. 테스트 보완
- 허용되지 않은 파일 형식 테스트 추가 (`validateUploadPolicy_invalidFileFormat`)
- 모든 UploadPolicyValidationServiceTest 통과 (10/10)

### 4. UploadSessionService 컴파일 에러 수정
- `UploadRequest.of()`에 IdempotencyKey 파라미터 추가
- `IdempotencyKey.generate()`를 통한 자동 생성

## ✅ Jira 완료 조건

- [x] Epic 1 테이블 이름 확인: `upload_policy`
- [x] 정책 위반 시나리오 테스트 3개 구현
  - [x] 파일 크기 초과
  - [x] 허용되지 않은 파일 타입
  - [x] 정책 허용 (모든 조건 만족)
- [x] PolicyViolationException 에러 응답 표준화
- [x] 통합 테스트 실행 및 통과

## 📊 테스트 결과

```
UploadPolicyValidationServiceTest: 10/10 통과 (100%)
├─ 파일 업로드 정책 검증: 6개 테스트
├─ Rate Limiting 검증: 2개 테스트
└─ 캐시 통합: 2개 테스트
```

## 📁 변경된 파일

- **신규**: `PolicyViolationErrorResponse.java`
- **수정**: `GlobalExceptionHandler.java`
- **수정**: `UploadPolicy.java` (determineViolationType 메서드 추가)
- **수정**: `UploadSessionService.java` (IdempotencyKey 추가)
- **수정**: `UploadPolicyValidationServiceTest.java` (테스트 케이스 추가)

## 🔗 Related Issue

- Jira: KAN-12
- Epic: KAN-10 (Epic 2: 파일 업로드 & 저장)

## 🧪 Test Plan

- [x] 단위 테스트 실행 및 통과
- [x] 통합 테스트 실행 및 통과
- [x] 정책 위반 시나리오별 에러 응답 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)