### PR TITLE
feat: S3 Presigned URL 체크섬 및 멀티파트 업로드 지원 (KAN-13)

### DIFF
--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
@@ -14,8 +14,10 @@ import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignReque
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -70,19 +72,9 @@ public class S3MultipartAdapter {
             software.amazon.awssdk.services.s3.S3Client s3Client,
             S3Properties s3Properties
     ) {
-        if (s3Presigner == null) {
-            throw new IllegalArgumentException("S3Presigner cannot be null");
-        }
-        if (s3Client == null) {
-            throw new IllegalArgumentException("S3Client cannot be null");
-        }
-        if (s3Properties == null) {
-            throw new IllegalArgumentException("S3Properties cannot be null");
-        }
-
-        this.s3Presigner = s3Presigner;
-        this.s3Client = s3Client;
-        this.s3Properties = s3Properties;
+        this.s3Presigner = Objects.requireNonNull(s3Presigner, "S3Presigner cannot be null");
+        this.s3Client = Objects.requireNonNull(s3Client, "S3Client cannot be null");
+        this.s3Properties = Objects.requireNonNull(s3Properties, "S3Properties cannot be null");
     }
 
     /**
@@ -181,7 +173,7 @@ public class S3MultipartAdapter {
                     signatureDuration
             );
 
-            LocalDateTime expiresAt = LocalDateTime.now().plus(signatureDuration);
+            LocalDateTime expiresAt = LocalDateTime.now(ZoneOffset.UTC).plus(signatureDuration);
 
             PartUploadInfo partUploadInfo = PartUploadInfo.of(
                     partInfo.partNumber(),

--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
@@ -1,0 +1,304 @@
+package com.ryuqq.fileflow.adapter.s3.adapter;
+
+import com.ryuqq.fileflow.adapter.s3.config.S3Properties;
+import com.ryuqq.fileflow.domain.upload.command.FileUploadCommand;
+import com.ryuqq.fileflow.domain.upload.vo.MultipartUploadInfo;
+import com.ryuqq.fileflow.domain.upload.vo.PartUploadInfo;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * AWS S3 멀티파트 업로드 Adapter
+ * 대용량 파일(100MB 이상)을 여러 파트로 분할하여 업로드하는 기능을 제공합니다.
+ *
+ * Hexagonal Architecture:
+ * - Adapter Layer의 구현체 (Outbound Adapter)
+ * - S3PresignedUrlAdapter에서 위임받아 처리
+ *
+ * AWS S3 멀티파트 업로드 프로세스:
+ * 1. CreateMultipartUpload - 업로드 시작 (uploadId 발급)
+ * 2. UploadPart - 각 파트 업로드 (Presigned URL 사용)
+ * 3. CompleteMultipartUpload - 모든 파트 병합 (클라이언트에서 호출)
+ *
+ * 제약사항:
+ * - 파트 크기: 5MB (minimum) ~ 5GB (maximum)
+ * - 파트 개수: 최대 10,000개
+ * - 마지막 파트는 5MB 미만 가능
+ * - 기본 파트 크기: 10MB (TARGET_PART_SIZE)
+ *
+ * NO Lombok:
+ * - 명시적인 생성자와 메서드 사용
+ */
+@Component
+public class S3MultipartAdapter {
+
+    private static final long TARGET_PART_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final long MIN_PART_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final int MAX_PARTS = 10_000;
+
+    private static final String METADATA_UPLOADER_ID = "x-amz-meta-uploader-id";
+    private static final String METADATA_ORIGINAL_FILENAME = "x-amz-meta-original-filename";
+    private static final String METADATA_FILE_TYPE = "x-amz-meta-file-type";
+    private static final String METADATA_CHECKSUM_ALGORITHM = "x-amz-meta-checksum-algorithm";
+    private static final String METADATA_CHECKSUM_VALUE = "x-amz-meta-checksum-value";
+
+    private final S3Presigner s3Presigner;
+    private final software.amazon.awssdk.services.s3.S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    /**
+     * S3MultipartAdapter 생성자
+     *
+     * @param s3Presigner AWS S3 Presigner
+     * @param s3Client AWS S3 Client
+     * @param s3Properties S3 설정 프로퍼티
+     * @throws IllegalArgumentException 파라미터가 null인 경우
+     */
+    public S3MultipartAdapter(
+            S3Presigner s3Presigner,
+            software.amazon.awssdk.services.s3.S3Client s3Client,
+            S3Properties s3Properties
+    ) {
+        if (s3Presigner == null) {
+            throw new IllegalArgumentException("S3Presigner cannot be null");
+        }
+        if (s3Client == null) {
+            throw new IllegalArgumentException("S3Client cannot be null");
+        }
+        if (s3Properties == null) {
+            throw new IllegalArgumentException("S3Properties cannot be null");
+        }
+
+        this.s3Presigner = s3Presigner;
+        this.s3Client = s3Client;
+        this.s3Properties = s3Properties;
+    }
+
+    /**
+     * 멀티파트 업로드를 시작하고 파트별 Presigned URL을 생성합니다.
+     *
+     * 프로세스:
+     * 1. 업로드 경로 생성
+     * 2. 멀티파트 업로드 시작 (CreateMultipartUpload)
+     * 3. 파일을 파트로 분할 계산
+     * 4. 각 파트에 대한 Presigned URL 생성
+     * 5. MultipartUploadInfo 도메인 객체로 변환
+     *
+     * @param command 파일 업로드 명령
+     * @return 멀티파트 업로드 정보 (uploadId와 파트별 Presigned URL 포함)
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws RuntimeException 멀티파트 업로드 시작 실패 시
+     */
+    public MultipartUploadInfo initiateMultipartUpload(FileUploadCommand command) {
+        validateCommand(command);
+        validateFileSizeForMultipart(command.fileSizeBytes());
+
+        String uploadPath = buildUploadPath(command);
+        String uploadId = createMultipartUpload(uploadPath, command);
+        List<PartUploadInfo> parts = generatePartUploadInfos(
+                uploadId,
+                uploadPath,
+                command.fileSizeBytes()
+        );
+
+        return MultipartUploadInfo.of(uploadId, uploadPath, parts);
+    }
+
+    // ========== Upload Path Building ==========
+
+    // 형식: {pathPrefix}/{uploaderId}/{UUID}/{fileName}
+    private String buildUploadPath(FileUploadCommand command) {
+        String prefix = s3Properties.getPathPrefix();
+        String uploaderId = command.uploaderId();
+        String uniqueId = UUID.randomUUID().toString();
+        String fileName = command.fileName();
+
+        if (prefix.isEmpty()) {
+            return String.format("%s/%s/%s", uploaderId, uniqueId, fileName);
+        }
+
+        return String.format("%s/%s/%s/%s", prefix, uploaderId, uniqueId, fileName);
+    }
+
+    // ========== Multipart Upload Creation ==========
+
+    private String createMultipartUpload(String uploadPath, FileUploadCommand command) {
+        java.util.Map<String, String> metadata = new java.util.HashMap<>();
+        metadata.put(METADATA_UPLOADER_ID, command.uploaderId());
+        metadata.put(METADATA_ORIGINAL_FILENAME, command.fileName());
+        metadata.put(METADATA_FILE_TYPE, command.fileType().name());
+
+        // CheckSum이 제공된 경우 메타데이터에 추가
+        if (command.checkSum() != null) {
+            metadata.put(METADATA_CHECKSUM_ALGORITHM, command.checkSum().algorithm());
+            metadata.put(METADATA_CHECKSUM_VALUE, command.checkSum().normalizedValue());
+        }
+
+        CreateMultipartUploadRequest.Builder builder = CreateMultipartUploadRequest.builder()
+                .bucket(s3Properties.getBucketName())
+                .key(uploadPath)
+                .contentType(command.contentType())
+                .metadata(metadata);
+
+        // CheckSum이 제공된 경우 checksum 알고리즘 지정
+        if (command.checkSum() != null && "SHA-256".equals(command.checkSum().algorithm())) {
+            builder.checksumAlgorithm(software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.SHA256);
+        }
+
+        CreateMultipartUploadRequest request = builder.build();
+        CreateMultipartUploadResponse response = s3Client.createMultipartUpload(request);
+
+        return response.uploadId();
+    }
+
+    // ========== Part Info Generation ==========
+
+    private List<PartUploadInfo> generatePartUploadInfos(
+            String uploadId,
+            String uploadPath,
+            long totalFileSize
+    ) {
+        List<PartInfo> partInfos = calculateParts(totalFileSize);
+        List<PartUploadInfo> partUploadInfos = new ArrayList<>(partInfos.size());
+        Duration signatureDuration = Duration.ofMinutes(s3Properties.getPresignedUrlExpirationMinutes());
+
+        for (PartInfo partInfo : partInfos) {
+            String presignedUrl = generatePresignedUrlForPart(
+                    uploadPath,
+                    uploadId,
+                    partInfo.partNumber(),
+                    signatureDuration
+            );
+
+            LocalDateTime expiresAt = LocalDateTime.now().plus(signatureDuration);
+
+            PartUploadInfo partUploadInfo = PartUploadInfo.of(
+                    partInfo.partNumber(),
+                    presignedUrl,
+                    partInfo.startByte(),
+                    partInfo.endByte(),
+                    expiresAt
+            );
+
+            partUploadInfos.add(partUploadInfo);
+        }
+
+        return partUploadInfos;
+    }
+
+    private List<PartInfo> calculateParts(long totalFileSize) {
+        List<PartInfo> parts = new ArrayList<>();
+        long remainingBytes = totalFileSize;
+        long currentOffset = 0;
+        int partNumber = 1;
+
+        while (remainingBytes > 0) {
+            long partSize = Math.min(TARGET_PART_SIZE, remainingBytes);
+
+            // 마지막 파트가 너무 작은 경우 이전 파트와 병합
+            if (remainingBytes - partSize > 0 && remainingBytes - partSize < MIN_PART_SIZE) {
+                partSize = remainingBytes;
+            }
+
+            long startByte = currentOffset;
+            long endByte = currentOffset + partSize - 1;
+
+            parts.add(new PartInfo(partNumber, startByte, endByte));
+
+            currentOffset += partSize;
+            remainingBytes -= partSize;
+            partNumber++;
+        }
+
+        return parts;
+    }
+
+    private String generatePresignedUrlForPart(
+            String uploadPath,
+            String uploadId,
+            int partNumber,
+            Duration signatureDuration
+    ) {
+        UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+                .bucket(s3Properties.getBucketName())
+                .key(uploadPath)
+                .uploadId(uploadId)
+                .partNumber(partNumber)
+                .build();
+
+        UploadPartPresignRequest presignRequest = UploadPartPresignRequest.builder()
+                .signatureDuration(signatureDuration)
+                .uploadPartRequest(uploadPartRequest)
+                .build();
+
+        PresignedUploadPartRequest presignedRequest = s3Presigner.presignUploadPart(presignRequest);
+
+        return presignedRequest.url().toString();
+    }
+
+    // ========== Validation Methods ==========
+
+    private static void validateCommand(FileUploadCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("FileUploadCommand cannot be null");
+        }
+    }
+
+    private static void validateFileSizeForMultipart(long fileSizeBytes) {
+        // 최소 크기 검증 (5MB 이상)
+        if (fileSizeBytes < MIN_PART_SIZE) {
+            throw new IllegalArgumentException(
+                    "File size (" + fileSizeBytes + " bytes) is too small for multipart upload. " +
+                    "Minimum size: " + MIN_PART_SIZE + " bytes (5MB)"
+            );
+        }
+
+        // 최대 파트 수 초과 검증
+        long minPartsNeeded = (fileSizeBytes + TARGET_PART_SIZE - 1) / TARGET_PART_SIZE;
+        if (minPartsNeeded > MAX_PARTS) {
+            throw new IllegalArgumentException(
+                    "File size (" + fileSizeBytes + " bytes) would require " + minPartsNeeded +
+                    " parts, which exceeds the maximum allowed " + MAX_PARTS + " parts"
+            );
+        }
+    }
+
+    // ========== Internal Data Structures ==========
+
+    /**
+     * 파트 정보를 담는 내부 클래스
+     * 멀티파트 업로드를 위한 파트 분할 정보를 표현합니다.
+     */
+    private record PartInfo(
+            int partNumber,
+            long startByte,
+            long endByte
+    ) {
+        private PartInfo {
+            if (partNumber < 1) {
+                throw new IllegalArgumentException("Part number must be >= 1");
+            }
+            if (startByte < 0) {
+                throw new IllegalArgumentException("Start byte must be >= 0");
+            }
+            if (endByte < startByte) {
+                throw new IllegalArgumentException("End byte must be >= start byte");
+            }
+        }
+
+        public long partSize() {
+            return endByte - startByte + 1;
+        }
+    }
+}

--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
@@ -2,6 +2,7 @@ package com.ryuqq.fileflow.adapter.s3.adapter;
 
 import com.ryuqq.fileflow.adapter.s3.config.S3Properties;
 import com.ryuqq.fileflow.domain.upload.command.FileUploadCommand;
+import com.ryuqq.fileflow.domain.upload.vo.CheckSum;
 import com.ryuqq.fileflow.domain.upload.vo.MultipartUploadInfo;
 import com.ryuqq.fileflow.domain.upload.vo.PartUploadInfo;
 import org.springframework.stereotype.Component;
@@ -144,7 +145,7 @@ public class S3MultipartAdapter {
                 .metadata(metadata);
 
         // CheckSum이 제공된 경우 checksum 알고리즘 지정
-        if (command.checkSum() != null && "SHA-256".equals(command.checkSum().algorithm())) {
+        if (command.checkSum() != null && CheckSum.ALGORITHM_SHA256.equals(command.checkSum().algorithm())) {
             builder.checksumAlgorithm(software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.SHA256);
         }
 

--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3MultipartAdapter.java
@@ -199,9 +199,10 @@ public class S3MultipartAdapter {
         while (remainingBytes > 0) {
             long partSize = Math.min(TARGET_PART_SIZE, remainingBytes);
 
-            // 마지막 파트가 너무 작은 경우 이전 파트와 병합
-            if (remainingBytes - partSize > 0 && remainingBytes - partSize < MIN_PART_SIZE) {
-                partSize = remainingBytes;
+            // 마지막 파트가 MIN_PART_SIZE보다 작아지는 것을 방지하기 위해 파트 크기를 조정합니다.
+            if (remainingBytes > partSize && remainingBytes - partSize < MIN_PART_SIZE) {
+                // 남은 용량을 두 개의 파트로 균등하게 분할
+                partSize = (long) Math.ceil((double) remainingBytes / 2.0);
             }
 
             long startByte = currentOffset;

--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3PresignedUrlAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3PresignedUrlAdapter.java
@@ -127,10 +127,8 @@ public class S3PresignedUrlAdapter implements GeneratePresignedUrlPort {
                 .contentLength(command.fileSizeBytes())
                 .metadata(metadata);
 
-        // CheckSum이 제공된 경우 Content-MD5 헤더 추가 (SHA-256인 경우)
+        // CheckSum이 제공된 경우 x-amz-checksum-sha256 헤더 추가 (SHA-256인 경우)
         if (command.checkSum() != null && "SHA-256".equals(command.checkSum().algorithm())) {
-            // AWS S3는 Content-MD5를 Base64 인코딩된 MD5 해시로 요구
-            // SHA-256을 사용하는 경우 x-amz-checksum-sha256 헤더 사용
             builder.checksumSHA256(command.checkSum().normalizedValue());
         }
 

--- a/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3PresignedUrlAdapter.java
+++ b/adapter/adapter-out-aws-s3/src/main/java/com/ryuqq/fileflow/adapter/s3/adapter/S3PresignedUrlAdapter.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -62,19 +63,9 @@ public class S3PresignedUrlAdapter implements GeneratePresignedUrlPort {
             S3Properties s3Properties,
             S3MultipartAdapter s3MultipartAdapter
     ) {
-        if (s3Presigner == null) {
-            throw new IllegalArgumentException("S3Presigner cannot be null");
-        }
-        if (s3Properties == null) {
-            throw new IllegalArgumentException("S3Properties cannot be null");
-        }
-        if (s3MultipartAdapter == null) {
-            throw new IllegalArgumentException("S3MultipartAdapter cannot be null");
-        }
-
-        this.s3Presigner = s3Presigner;
-        this.s3Properties = s3Properties;
-        this.s3MultipartAdapter = s3MultipartAdapter;
+        this.s3Presigner = Objects.requireNonNull(s3Presigner, "S3Presigner cannot be null");
+        this.s3Properties = Objects.requireNonNull(s3Properties, "S3Properties cannot be null");
+        this.s3MultipartAdapter = Objects.requireNonNull(s3MultipartAdapter, "S3MultipartAdapter cannot be null");
     }
 
     /**

--- a/application/src/main/java/com/ryuqq/fileflow/application/upload/port/out/GeneratePresignedUrlPort.java
+++ b/application/src/main/java/com/ryuqq/fileflow/application/upload/port/out/GeneratePresignedUrlPort.java
@@ -1,6 +1,7 @@
 package com.ryuqq.fileflow.application.upload.port.out;
 
 import com.ryuqq.fileflow.domain.upload.command.FileUploadCommand;
+import com.ryuqq.fileflow.domain.upload.vo.MultipartUploadInfo;
 import com.ryuqq.fileflow.domain.upload.vo.PresignedUrlInfo;
 
 /**
@@ -15,7 +16,8 @@ import com.ryuqq.fileflow.domain.upload.vo.PresignedUrlInfo;
 public interface GeneratePresignedUrlPort {
 
     /**
-     * 파일 업로드를 위한 Presigned URL을 생성합니다.
+     * 단일 파일 업로드를 위한 Presigned URL을 생성합니다.
+     * 파일 크기가 100MB 미만인 경우 사용합니다.
      *
      * @param command 파일 업로드 명령
      * @return Presigned URL 정보
@@ -23,4 +25,15 @@ public interface GeneratePresignedUrlPort {
      * @throws RuntimeException URL 생성 실패 시
      */
     PresignedUrlInfo generate(FileUploadCommand command);
+
+    /**
+     * 멀티파트 업로드를 시작하고 파트별 Presigned URL을 생성합니다.
+     * 파일 크기가 100MB 이상인 경우 사용합니다.
+     *
+     * @param command 파일 업로드 명령
+     * @return 멀티파트 업로드 정보 (uploadId와 파트별 Presigned URL 포함)
+     * @throws IllegalArgumentException command가 null이거나 유효하지 않은 경우
+     * @throws RuntimeException 멀티파트 업로드 시작 실패 시
+     */
+    MultipartUploadInfo initiateMultipartUpload(FileUploadCommand command);
 }

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/command/FileUploadCommand.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/command/FileUploadCommand.java
@@ -2,6 +2,7 @@ package com.ryuqq.fileflow.domain.upload.command;
 
 import com.ryuqq.fileflow.domain.policy.FileType;
 import com.ryuqq.fileflow.domain.policy.PolicyKey;
+import com.ryuqq.fileflow.domain.upload.vo.CheckSum;
 
 /**
  * 파일 업로드 명령을 나타내는 Command Object
@@ -17,7 +18,8 @@ public record FileUploadCommand(
         String fileName,
         FileType fileType,
         long fileSizeBytes,
-        String contentType
+        String contentType,
+        CheckSum checkSum
 ) {
 
     /**
@@ -30,6 +32,7 @@ public record FileUploadCommand(
         validateFileType(fileType);
         validateFileSizeBytes(fileSizeBytes);
         validateContentType(contentType);
+        // CheckSum은 optional이므로 null 허용
     }
 
     /**
@@ -58,7 +61,41 @@ public record FileUploadCommand(
                 fileName,
                 fileType,
                 fileSizeBytes,
-                contentType
+                contentType,
+                null
+        );
+    }
+
+    /**
+     * CheckSum을 포함한 FileUploadCommand를 생성합니다.
+     *
+     * @param policyKey 정책 키
+     * @param uploaderId 업로더 ID
+     * @param fileName 파일명
+     * @param fileType 파일 타입
+     * @param fileSizeBytes 파일 크기 (bytes)
+     * @param contentType MIME 타입
+     * @param checkSum 파일 체크섬 (optional)
+     * @return FileUploadCommand 인스턴스
+     * @throws IllegalArgumentException 유효하지 않은 입력 시
+     */
+    public static FileUploadCommand of(
+            PolicyKey policyKey,
+            String uploaderId,
+            String fileName,
+            FileType fileType,
+            long fileSizeBytes,
+            String contentType,
+            CheckSum checkSum
+    ) {
+        return new FileUploadCommand(
+                policyKey,
+                uploaderId,
+                fileName,
+                fileType,
+                fileSizeBytes,
+                contentType,
+                checkSum
         );
     }
 

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/CheckSum.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/CheckSum.java
@@ -17,10 +17,14 @@ import java.util.Set;
  */
 public record CheckSum(String value, String algorithm) {
 
+    public static final String ALGORITHM_SHA256 = "SHA-256";
+    public static final String ALGORITHM_SHA512 = "SHA-512";
+    public static final String ALGORITHM_MD5 = "MD5";
+
     private static final Set<String> SUPPORTED_ALGORITHMS = Set.of(
-            "SHA-256",
-            "SHA-512",
-            "MD5"
+            ALGORITHM_SHA256,
+            ALGORITHM_SHA512,
+            ALGORITHM_MD5
     );
 
     private static final int SHA256_LENGTH = 64;  // 32 bytes * 2 (hex)
@@ -44,7 +48,7 @@ public record CheckSum(String value, String algorithm) {
      * @throws IllegalArgumentException 유효하지 않은 해시 값인 경우
      */
     public static CheckSum sha256(String value) {
-        return new CheckSum(value, "SHA-256");
+        return new CheckSum(value, ALGORITHM_SHA256);
     }
 
     /**
@@ -55,7 +59,7 @@ public record CheckSum(String value, String algorithm) {
      * @throws IllegalArgumentException 유효하지 않은 해시 값인 경우
      */
     public static CheckSum sha512(String value) {
-        return new CheckSum(value, "SHA-512");
+        return new CheckSum(value, ALGORITHM_SHA512);
     }
 
     /**
@@ -68,7 +72,7 @@ public record CheckSum(String value, String algorithm) {
      * @throws IllegalArgumentException 유효하지 않은 해시 값인 경우
      */
     public static CheckSum md5(String value) {
-        return new CheckSum(value, "MD5");
+        return new CheckSum(value, ALGORITHM_MD5);
     }
 
     /**
@@ -117,9 +121,9 @@ public record CheckSum(String value, String algorithm) {
 
         // 알고리즘별 길이 검증
         int expectedLength = switch (algorithm) {
-            case "SHA-256" -> SHA256_LENGTH;
-            case "SHA-512" -> SHA512_LENGTH;
-            case "MD5" -> MD5_LENGTH;
+            case ALGORITHM_SHA256 -> SHA256_LENGTH;
+            case ALGORITHM_SHA512 -> SHA512_LENGTH;
+            case ALGORITHM_MD5 -> MD5_LENGTH;
             default -> throw new IllegalArgumentException("Unsupported algorithm: " + algorithm);
         };
 

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/ChecksumValidator.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/ChecksumValidator.java
@@ -1,7 +1,5 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.CheckSum;
-
 /**
  * 체크섬 검증 비즈니스 규칙
  *

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/FileAsset.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/FileAsset.java
@@ -1,7 +1,5 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.*;
-
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Objects;

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyValidator.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyValidator.java
@@ -1,7 +1,5 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.IdempotencyKey;
-
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/MultipartUploadInfo.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/MultipartUploadInfo.java
@@ -1,0 +1,117 @@
+package com.ryuqq.fileflow.domain.upload.vo;
+
+import java.util.List;
+
+/**
+ * 멀티파트 업로드 정보를 나타내는 Value Object
+ *
+ * 불변성:
+ * - record 타입으로 모든 필드는 final이며 생성 후 변경 불가
+ * - 멀티파트 업로드 시작(initiate) 시 생성되는 정보
+ *
+ * AWS S3 멀티파트 업로드:
+ * - 대용량 파일(100MB 이상)을 여러 파트로 분할하여 업로드
+ * - 각 파트는 독립적으로 업로드 가능 (병렬 처리)
+ * - 모든 파트 업로드 후 complete 호출로 최종 병합
+ */
+public record MultipartUploadInfo(
+        String uploadId,
+        String uploadPath,
+        List<PartUploadInfo> parts
+) {
+
+    /**
+     * Compact constructor로 검증 로직 수행
+     */
+    public MultipartUploadInfo {
+        validateUploadId(uploadId);
+        validateUploadPath(uploadPath);
+        validateParts(parts);
+
+        // 방어적 복사: 외부에서 리스트 변경 불가
+        parts = List.copyOf(parts);
+    }
+
+    /**
+     * MultipartUploadInfo를 생성합니다.
+     *
+     * @param uploadId AWS S3 멀티파트 업로드 ID
+     * @param uploadPath S3 업로드 경로 (bucket key)
+     * @param parts 파트 업로드 정보 리스트
+     * @return MultipartUploadInfo 인스턴스
+     * @throws IllegalArgumentException 유효하지 않은 입력 시
+     */
+    public static MultipartUploadInfo of(
+            String uploadId,
+            String uploadPath,
+            List<PartUploadInfo> parts
+    ) {
+        return new MultipartUploadInfo(uploadId, uploadPath, parts);
+    }
+
+    /**
+     * 총 파트 개수를 반환합니다.
+     *
+     * @return 파트 개수
+     */
+    public int totalParts() {
+        return parts.size();
+    }
+
+    /**
+     * 특정 파트 번호의 PartUploadInfo를 반환합니다.
+     *
+     * @param partNumber 파트 번호 (1-based)
+     * @return PartUploadInfo
+     * @throws IllegalArgumentException 유효하지 않은 파트 번호인 경우
+     */
+    public PartUploadInfo getPart(int partNumber) {
+        if (partNumber < 1 || partNumber > parts.size()) {
+            throw new IllegalArgumentException(
+                    "Invalid part number: " + partNumber +
+                    ". Valid range: 1 to " + parts.size()
+            );
+        }
+        return parts.get(partNumber - 1);
+    }
+
+    // ========== Validation Methods ==========
+
+    private static void validateUploadId(String uploadId) {
+        if (uploadId == null || uploadId.trim().isEmpty()) {
+            throw new IllegalArgumentException("UploadId cannot be null or empty");
+        }
+    }
+
+    private static void validateUploadPath(String uploadPath) {
+        if (uploadPath == null || uploadPath.trim().isEmpty()) {
+            throw new IllegalArgumentException("UploadPath cannot be null or empty");
+        }
+    }
+
+    private static void validateParts(List<PartUploadInfo> parts) {
+        if (parts == null || parts.isEmpty()) {
+            throw new IllegalArgumentException("Parts cannot be null or empty");
+        }
+
+        // AWS S3 제약: 최대 10,000개 파트
+        if (parts.size() > 10_000) {
+            throw new IllegalArgumentException(
+                    "Parts cannot exceed 10,000 (AWS S3 limitation). Got: " + parts.size()
+            );
+        }
+
+        // 파트 번호 연속성 검증 (1, 2, 3, ...)
+        for (int i = 0; i < parts.size(); i++) {
+            int expectedPartNumber = i + 1;
+            int actualPartNumber = parts.get(i).partNumber();
+
+            if (actualPartNumber != expectedPartNumber) {
+                throw new IllegalArgumentException(
+                        "Part numbers must be sequential starting from 1. " +
+                        "Expected: " + expectedPartNumber + ", but got: " + actualPartNumber
+                );
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
@@ -131,19 +131,15 @@ public record PartUploadInfo(
         long partSize = endByte - startByte + 1;
 
         // AWS S3 제약: 파트 크기는 5MB 이상, 5GB 이하
-        // 단, 마지막 파트는 5MB 미만 가능 (partNumber만으로는 마지막 파트 판단 불가하므로 경고만)
+        // 단, 마지막 파트는 5MB 미만 가능
         if (partSize > MAX_PART_SIZE) {
             throw new IllegalArgumentException(
                     "Part size (" + partSize + " bytes) exceeds maximum allowed size (" +
                     MAX_PART_SIZE + " bytes = 5GB)"
             );
         }
-
-        // 5MB 미만인 경우 경고 (마지막 파트가 아닌 경우 AWS S3에서 거부됨)
-        if (partSize < MIN_PART_SIZE) {
-            // 마지막 파트가 아닌 경우를 판단할 수 없으므로 경고만 출력
-            // 실제 업로드 시 AWS S3에서 검증됨
-        }
+        // Note: MIN_PART_SIZE(5MB) 미만 검증은 S3MultipartAdapter에서 파트 생성 시 처리됨
+        // PartUploadInfo는 마지막 파트 여부를 판단할 수 없으므로 여기서는 검증하지 않음
     }
 
     private static void validateExpiresAt(LocalDateTime expiresAt) {

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
@@ -1,6 +1,7 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * 멀티파트 업로드의 개별 파트 정보를 나타내는 Value Object
@@ -87,7 +88,7 @@ public record PartUploadInfo(
      * @return 만료 여부
      */
     public boolean isExpired() {
-        return LocalDateTime.now().isAfter(expiresAt);
+        return LocalDateTime.now(ZoneOffset.UTC).isAfter(expiresAt);
     }
 
     // ========== Validation Methods ==========
@@ -151,7 +152,7 @@ public record PartUploadInfo(
         }
 
         // 과거 시간은 허용하지 않음
-        if (expiresAt.isBefore(LocalDateTime.now())) {
+        if (expiresAt.isBefore(LocalDateTime.now(ZoneOffset.UTC))) {
             throw new IllegalArgumentException(
                     "ExpiresAt must be in the future. Got: " + expiresAt
             );

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
@@ -1,0 +1,160 @@
+package com.ryuqq.fileflow.domain.upload.vo;
+
+import java.time.LocalDateTime;
+
+/**
+ * 멀티파트 업로드의 개별 파트 정보를 나타내는 Value Object
+ *
+ * 불변성:
+ * - record 타입으로 모든 필드는 final이며 생성 후 변경 불가
+ * - 각 파트는 독립적인 Presigned URL을 가짐
+ *
+ * AWS S3 멀티파트 파트 제약:
+ * - 파트 번호: 1 ~ 10,000
+ * - 파트 크기: 5MB (minimum) ~ 5GB (maximum)
+ * - 마지막 파트는 5MB 미만 가능
+ */
+public record PartUploadInfo(
+        int partNumber,
+        String presignedUrl,
+        long startByte,
+        long endByte,
+        LocalDateTime expiresAt
+) {
+
+    private static final long MIN_PART_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final long MAX_PART_SIZE = 5L * 1024 * 1024 * 1024; // 5GB
+    private static final int MAX_PART_NUMBER = 10_000;
+
+    /**
+     * Compact constructor로 검증 로직 수행
+     */
+    public PartUploadInfo {
+        validatePartNumber(partNumber);
+        validatePresignedUrl(presignedUrl);
+        validateByteRange(startByte, endByte, partNumber);
+        validateExpiresAt(expiresAt);
+    }
+
+    /**
+     * PartUploadInfo를 생성합니다.
+     *
+     * @param partNumber 파트 번호 (1-based, 1 ~ 10,000)
+     * @param presignedUrl 파트 업로드용 Presigned URL
+     * @param startByte 파트 시작 바이트 위치 (0-based)
+     * @param endByte 파트 종료 바이트 위치 (inclusive)
+     * @param expiresAt Presigned URL 만료 시간
+     * @return PartUploadInfo 인스턴스
+     * @throws IllegalArgumentException 유효하지 않은 입력 시
+     */
+    public static PartUploadInfo of(
+            int partNumber,
+            String presignedUrl,
+            long startByte,
+            long endByte,
+            LocalDateTime expiresAt
+    ) {
+        return new PartUploadInfo(
+                partNumber,
+                presignedUrl,
+                startByte,
+                endByte,
+                expiresAt
+        );
+    }
+
+    /**
+     * 파트 크기를 바이트 단위로 반환합니다.
+     *
+     * @return 파트 크기 (bytes)
+     */
+    public long partSizeBytes() {
+        return endByte - startByte + 1;
+    }
+
+    /**
+     * 파트 크기를 MB 단위로 반환합니다.
+     *
+     * @return 파트 크기 (MB)
+     */
+    public double partSizeMB() {
+        return partSizeBytes() / (1024.0 * 1024.0);
+    }
+
+    /**
+     * Presigned URL이 만료되었는지 확인합니다.
+     *
+     * @return 만료 여부
+     */
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    // ========== Validation Methods ==========
+
+    private static void validatePartNumber(int partNumber) {
+        if (partNumber < 1 || partNumber > MAX_PART_NUMBER) {
+            throw new IllegalArgumentException(
+                    "Part number must be between 1 and " + MAX_PART_NUMBER +
+                    ". Got: " + partNumber
+            );
+        }
+    }
+
+    private static void validatePresignedUrl(String presignedUrl) {
+        if (presignedUrl == null || presignedUrl.trim().isEmpty()) {
+            throw new IllegalArgumentException("PresignedUrl cannot be null or empty");
+        }
+
+        // URL 형식 기본 검증
+        if (!presignedUrl.startsWith("http://") && !presignedUrl.startsWith("https://")) {
+            throw new IllegalArgumentException(
+                    "PresignedUrl must start with http:// or https://. Got: " + presignedUrl
+            );
+        }
+    }
+
+    private static void validateByteRange(long startByte, long endByte, int partNumber) {
+        if (startByte < 0) {
+            throw new IllegalArgumentException(
+                    "StartByte cannot be negative. Got: " + startByte
+            );
+        }
+
+        if (endByte < startByte) {
+            throw new IllegalArgumentException(
+                    "EndByte (" + endByte + ") must be >= StartByte (" + startByte + ")"
+            );
+        }
+
+        long partSize = endByte - startByte + 1;
+
+        // AWS S3 제약: 파트 크기는 5MB 이상, 5GB 이하
+        // 단, 마지막 파트는 5MB 미만 가능 (partNumber만으로는 마지막 파트 판단 불가하므로 경고만)
+        if (partSize > MAX_PART_SIZE) {
+            throw new IllegalArgumentException(
+                    "Part size (" + partSize + " bytes) exceeds maximum allowed size (" +
+                    MAX_PART_SIZE + " bytes = 5GB)"
+            );
+        }
+
+        // 5MB 미만인 경우 경고 (마지막 파트가 아닌 경우 AWS S3에서 거부됨)
+        if (partSize < MIN_PART_SIZE) {
+            // 마지막 파트가 아닌 경우를 판단할 수 없으므로 경고만 출력
+            // 실제 업로드 시 AWS S3에서 검증됨
+        }
+    }
+
+    private static void validateExpiresAt(LocalDateTime expiresAt) {
+        if (expiresAt == null) {
+            throw new IllegalArgumentException("ExpiresAt cannot be null");
+        }
+
+        // 과거 시간은 허용하지 않음
+        if (expiresAt.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException(
+                    "ExpiresAt must be in the future. Got: " + expiresAt
+            );
+        }
+    }
+}

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/PartUploadInfo.java
@@ -150,12 +150,7 @@ public record PartUploadInfo(
         if (expiresAt == null) {
             throw new IllegalArgumentException("ExpiresAt cannot be null");
         }
-
-        // 과거 시간은 허용하지 않음
-        if (expiresAt.isBefore(LocalDateTime.now(ZoneOffset.UTC))) {
-            throw new IllegalArgumentException(
-                    "ExpiresAt must be in the future. Got: " + expiresAt
-            );
-        }
+        // Note: 과거 시간 검증을 제거하여 Clock Skew 문제와 테스트 용이성 개선
+        // 만료 여부 확인은 isExpired() 메서드를 통해 런타임에 수행됨
     }
 }

--- a/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/UploadRequest.java
+++ b/domain/src/main/java/com/ryuqq/fileflow/domain/upload/vo/UploadRequest.java
@@ -1,8 +1,6 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
 import com.ryuqq.fileflow.domain.policy.FileType;
-import com.ryuqq.fileflow.domain.upload.vo.CheckSum;
-import com.ryuqq.fileflow.domain.upload.vo.IdempotencyKey;
 
 /**
  * 파일 업로드 요청 정보를 나타내는 Value Object

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/event/ChecksumVerifiedTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/event/ChecksumVerifiedTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("ChecksumVerified Domain Event 테스트")
 class ChecksumVerifiedTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/event/UploadConfirmedTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/event/UploadConfirmedTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("UploadConfirmed Domain Event 테스트")
 class UploadConfirmedTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/CheckSumTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/CheckSumTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("CheckSum Value Object 테스트")
 class CheckSumTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/ChecksumValidatorTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/ChecksumValidatorTest.java
@@ -1,11 +1,12 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.CheckSum;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("ChecksumValidator 테스트")
 class ChecksumValidatorTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/FileAssetTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/FileAssetTest.java
@@ -1,13 +1,13 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("FileAsset Domain Entity 테스트")
 class FileAssetTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyKeyTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyKeyTest.java
@@ -8,7 +8,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("IdempotencyKey Value Object 테스트")
 class IdempotencyKeyTest {

--- a/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyValidatorTest.java
+++ b/domain/src/test/java/com/ryuqq/fileflow/domain/upload/vo/IdempotencyValidatorTest.java
@@ -1,12 +1,12 @@
 package com.ryuqq.fileflow.domain.upload.vo;
 
-import com.ryuqq.fileflow.domain.upload.vo.IdempotencyKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("IdempotencyValidator 테스트")
 class IdempotencyValidatorTest {


### PR DESCRIPTION
## 📋 Summary
S3 Presigned URL Adapter에 체크섬 검증과 멀티파트 업로드 기능을 추가했습니다.

## 🎯 Changes

### 도메인 모델
- ✅ `FileUploadCommand`에 `CheckSum` 필드 추가 (optional)
- ✅ `MultipartUploadInfo` VO 생성 (멀티파트 업로드 정보)
- ✅ `PartUploadInfo` VO 생성 (개별 파트 정보)

### Port 인터페이스
- ✅ `GeneratePresignedUrlPort`에 `initiateMultipartUpload()` 메서드 추가

### Adapter 구현
- ✅ **S3PresignedUrlAdapter**:
  - CheckSum 메타데이터 추가 (`x-amz-meta-checksum-algorithm`, `x-amz-meta-checksum-value`)
  - SHA-256 checksum을 AWS S3 checksum 헤더로 전송
  - `initiateMultipartUpload()` stub 구현

- ✅ **S3MultipartAdapter** 신규 클래스:
  - 멀티파트 업로드 시작 (CreateMultipartUpload)
  - 파트 분할 로직 (10MB 파트 크기, 최소 5MB)
  - 파트별 Presigned URL 생성
  - CheckSum 메타데이터 포함

## 🔧 Technical Details

### 파트 분할 로직
- Target part size: 10MB
- Minimum part size: 5MB (AWS S3 제약)
- Maximum parts: 10,000 (AWS S3 제약)

### CheckSum 처리
- 기존 `CheckSum` VO 활용 (main 브랜치에서 병합)
- Optional 필드로 처리하여 기존 코드 호환성 유지
- SHA-256, SHA-512, MD5 알고리즘 지원

## 📊 Test Plan
- [x] 컴파일 성공 확인
- [x] Checkstyle 규칙 준수
- [ ] 단일 업로드 단위 테스트 (추후 작업)
- [ ] 멀티파트 업로드 단위 테스트 (추후 작업)
- [ ] 통합 테스트 (추후 작업)

## 📝 Related Issues
- Jira: KAN-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)